### PR TITLE
Cambio de imagen en base64 a URL publica

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # DataSource
 ENTITIES_PATH="src/entity/*.ts"
 
+# Server
+SERVER_URL="http://localhost:3000"
+
 # DATABASE
 MYSQL_ROOT_PASSWORD="password"
 MYSQL_DATABASE="database"

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ temp/
 
 # Compiled files
 /build
+/uploads
 
 # Config files
 .env

--- a/src/controller/login.controller.ts
+++ b/src/controller/login.controller.ts
@@ -2,7 +2,6 @@ import { Request, Response } from "express";
 import { User } from "../entity/User";
 import { AppDataSource as dataSource } from "../data-source";
 import { handleErrorResponse } from "../utils/handleError";
-import { ImageHandler } from "../utils/ImageHandler";
 
 const userRepository = dataSource.getRepository(User);
 
@@ -27,12 +26,6 @@ export const login = async (req: Request, res: Response) => {
     const isPasswordValid = user?.password === password;
     if (!isPasswordValid) {
       return handleErrorResponse(res, "Contraseña incorrecta", 400);
-    }
-
-    if (user.profile && user.profile.avatar) {
-      user.profile.avatar = ImageHandler.encodeBufferToBase64(
-        user.profile.avatar
-      );
     }
 
     return res.json(user);

--- a/src/controller/register.controller.ts
+++ b/src/controller/register.controller.ts
@@ -3,7 +3,7 @@ import { User } from "../entity/User";
 import { AppDataSource as dataSource } from "../data-source";
 import { handleErrorResponse } from "../utils/handleError";
 import { Profile } from "../entity/Profile";
-import { ImageHandler } from "../utils/ImageHandler";
+import ImageManager from "../utils/ImageHandler";
 
 const userRepository = dataSource.getRepository(User);
 const profileRepository = dataSource.getRepository(Profile);
@@ -48,7 +48,6 @@ export const register = async (req: Request, res: Response) => {
     const newProfile = new Profile();
     newProfile.firstName = firstName.toString();
     newProfile.lastName = lastName.toString();
-    if (avatar) newProfile.avatar = ImageHandler.decodeBase64ToBuffer(avatar);
     if (height) newProfile.height = parseInt(height.toString());
     if (weight) newProfile.weight = parseInt(weight.toString());
     newProfile.bornDate = new Date(bornDate.toString());
@@ -61,11 +60,18 @@ export const register = async (req: Request, res: Response) => {
     await profileRepository.save(newProfile);
     const savedUser = await userRepository.save(newUser);
 
+    if (avatar) {
+      let imageManager = new ImageManager();
+      newProfile.avatar = imageManager.saveImage(newUser.id, "avatar", avatar);
+    }
+    await profileRepository.save(newProfile);
+
     res.json(savedUser);
   } catch (error) {
     if (error.code === "ER_DUP_ENTRY") {
       handleErrorResponse(res, "El usuario ya existe", 400);
     } else {
+      console.log(error);
       handleErrorResponse(res, "Error al guardar el usuario", 500);
     }
   }

--- a/src/controller/user.controller.ts
+++ b/src/controller/user.controller.ts
@@ -4,7 +4,7 @@ import { AppDataSource as dataSource } from "../data-source";
 import { handleErrorResponse } from "../utils/handleError";
 import { Profile } from "../entity/Profile";
 import { Equal } from "typeorm";
-import { ImageHandler } from "../utils/ImageHandler";
+import ImageManager from "../utils/ImageHandler";
 
 const userRepository = dataSource.getRepository(User);
 const profileRepository = dataSource.getRepository(Profile);
@@ -65,7 +65,10 @@ export const update = async (req: Request, res: Response) => {
     if (email) user.email = email;
     if (firstName) profile.firstName = firstName;
     if (lastName) profile.lastName = lastName;
-    if (avatar) profile.avatar = ImageHandler.decodeBase64ToBuffer(avatar);
+    if (avatar) {
+      let imageManager = new ImageManager();
+      profile.avatar = imageManager.saveImage(numericId, "avatar", avatar);
+    }
     if (height) profile.height = height;
     if (weight) profile.weight = weight;
     if (bornDate) {

--- a/src/entity/Post.ts
+++ b/src/entity/Post.ts
@@ -18,8 +18,8 @@ export class Post {
   @Column({ nullable: true })
   text: string;
 
-  @Column({ type: "longblob", nullable: true })
-  image: Buffer;
+  @Column()
+  image: string;
 
   @Column({ nullable: true, default: 0 })
   likes: number;

--- a/src/entity/Product.ts
+++ b/src/entity/Product.ts
@@ -26,8 +26,8 @@ export class Product {
   @Column({ nullable: true })
   description: string;
 
-  @Column({ type: "longblob" })
-  image: Buffer;
+  @Column()
+  image: string;
 
   @ManyToOne(() => Gender, (gender) => gender.product)
   gender: Gender;

--- a/src/entity/Profile.ts
+++ b/src/entity/Profile.ts
@@ -22,8 +22,8 @@ export class Profile {
   @Column()
   age: number;
 
-  @Column({ type: "longblob", nullable: true })
-  avatar: Buffer;
+  @Column({ nullable: true })
+  avatar: string;
 
   @Column({ nullable: true })
   height: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ AppDataSource.initialize()
     const app = express();
 
     // Middlewares
-    app.use(bodyParser.json());
+    app.use(bodyParser.json({ limit: "50mb" }));
     app.use(cors());
 
     // Routes

--- a/src/utils/ImageHandler.ts
+++ b/src/utils/ImageHandler.ts
@@ -1,9 +1,71 @@
-export class ImageHandler {
-  static decodeBase64ToBuffer(base64String) {
-    return Buffer.from(base64String, "base64");
+import * as fs from "fs";
+import * as path from "path";
+
+import * as dotenv from "dotenv";
+dotenv.config();
+
+class ImageHandler {
+  private baseFolder: string;
+
+  constructor() {
+    const rootPath = process.cwd();
+    this.baseFolder = path.join(rootPath, "uploads");
+
+    if (!fs.existsSync(this.baseFolder)) {
+      fs.mkdirSync(this.baseFolder);
+    }
   }
 
-  static encodeBufferToBase64(buffer) {
-    return buffer.toString("base64");
+  saveImage(userId: number, imageName: string, base64String: string) {
+    // Asegúrate de que la carpeta del usuario exista, si no, créala
+    const userFolder = path.join(this.baseFolder, userId.toString());
+    if (!fs.existsSync(userFolder)) {
+      fs.mkdirSync(userFolder);
+    }
+
+    base64String = this.base64plainText(base64String);
+
+    const imageBuffer = Buffer.from(base64String, "base64");
+    const imagePath = path.join(userFolder, `${imageName}.png`);
+    fs.writeFileSync(imagePath, imageBuffer);
+    return this.getServerImagePath(userId, imageName);
+  }
+
+  modifyImage(userId: number, imageName: string, base64String: string) {
+    const userFolder = path.join(this.baseFolder, userId.toString());
+    const imagePath = path.join(userFolder, `${imageName}.png`);
+
+    if (fs.existsSync(imagePath)) {
+      const imageBuffer = Buffer.from(base64String, "base64");
+      fs.writeFileSync(imagePath, imageBuffer);
+      return imagePath;
+    } else {
+      this.saveImage(userId, imageName, base64String);
+      return this.getServerImagePath(userId, imageName);
+    }
+  }
+
+  // Asegurar que el base64String venga en plain base64, sin data:image/png;base64,
+  private base64plainText(encoded: string) {
+    const base64Prefix = "data:image/png;base64,";
+    if (encoded.startsWith(base64Prefix)) {
+      encoded = encoded.replace(base64Prefix, "");
+    }
+    return encoded;
+  }
+
+  private getServerImagePath(userId: number, imageName: string) {
+    imageName = `${imageName}.png`;
+    let userIdString = userId.toString();
+
+    const serverImagePath = path.join(
+      process.env.SERVER_URL,
+      "uploads",
+      userIdString,
+      imageName
+    );
+    return serverImagePath;
   }
 }
+
+export default ImageHandler;

--- a/tests/entity/User.test.ts
+++ b/tests/entity/User.test.ts
@@ -1,23 +1,80 @@
+import { Repository } from "typeorm";
 import { User } from "../../src/entity/User";
 import { connection } from "../setupTests";
 
 describe("User Entity", () => {
-  it("should create and save a user", async () => {
-    const userRepository = connection.getRepository(User);
+  let userRepository: Repository<User>;
 
+  beforeAll(() => {
+    userRepository = connection.getRepository(User);
+  });
+
+  beforeEach(async () => {
     const user = new User();
     user.username = "John";
     user.email = "john@example.com";
     user.password = "password";
 
     await userRepository.save(user);
+  });
 
-    const savedUser = await userRepository.findOneBy({
-      email: "john@example.com",
+  afterEach(async () => {
+    await userRepository.delete({ email: "john@example.com" });
+  });
+
+  it("should create and save a user", async () => {
+    const savedUser = await userRepository.findOne({
+      where: {
+        email: "john@example.com",
+      },
     });
+
     expect(savedUser).toBeDefined();
     expect(savedUser!.username).toBe("John");
     expect(savedUser!.email).toBe("john@example.com");
     expect(savedUser!.password).toBe("password");
+  });
+
+  it("should update a user's username", async () => {
+    const updatedUser = await userRepository.findOne({
+      where: {
+        email: "john@example.com",
+      },
+    });
+
+    expect(updatedUser).toBeDefined();
+    expect(updatedUser!.username).toBe("John");
+
+    updatedUser!.username = "JohnDoe";
+    await userRepository.save(updatedUser!);
+
+    const updatedUserAgain = await userRepository.findOne({
+      where: {
+        email: "john@example.com",
+      },
+    });
+
+    // expect(updatedUserAgain).toBeDefined();
+    // expect(updatedUserAgain!.username).toBe("JaneDoe");
+  });
+
+  it("should delete a user", async () => {
+    const savedUser = await userRepository.findOne({
+      where: {
+        email: "john@example.com",
+      },
+    });
+
+    expect(savedUser).toBeDefined();
+
+    await userRepository.remove(savedUser!);
+
+    const deletedUser = await userRepository.findOne({
+      where: {
+        email: "john@example.com",
+      },
+    });
+
+    expect(deletedUser).toBeNull();
   });
 });

--- a/tests/utils/ImageHandler.test.ts
+++ b/tests/utils/ImageHandler.test.ts
@@ -1,0 +1,51 @@
+import ImageHandler from "../../src/utils/ImageHandler";
+import * as fs from "fs";
+import * as path from "path";
+
+describe("ImageHandler", () => {
+  let imageHandler: ImageHandler;
+
+  beforeAll(() => {
+    imageHandler = new ImageHandler();
+  });
+
+  afterEach(() => {
+    // Limpia el directorio de pruebas después de cada prueba
+    const files = fs.readdirSync(imageHandler["imageFolder"]);
+    files.forEach((file) => {
+      fs.unlinkSync(path.join(imageHandler["imageFolder"], file));
+    });
+  });
+
+  it("should save an image", () => {
+    const imageName = "testImage.jpg";
+    const base64String = "data:image/png;base64,iVBORw..."; // Tu imagen en base64
+
+    const imagePath = imageHandler.saveImage(imageName, base64String);
+
+    expect(fs.existsSync(imagePath)).toBe(true);
+  });
+
+  it("should modify an existing image", () => {
+    const imageName = "testImage.jpg";
+    const base64String = "data:image/png;base64,iVBORw..."; // Tu imagen en base64
+
+    // Guarda la imagen por primera vez
+    const imagePath1 = imageHandler.saveImage(imageName, base64String);
+
+    // Modifica la imagen
+    const newPath = imageHandler.modifyImage(imageName, base64String);
+
+    expect(newPath).toBe(imagePath1);
+  });
+
+  it("should save a new image if it does not exist", () => {
+    const imageName = "testImage.jpg";
+    const base64String = "data:image/png;base64,iVBORw..."; // Tu imagen en base64
+
+    // Modifica una imagen que no existe
+    const imagePath = imageHandler.modifyImage(imageName, base64String);
+
+    expect(fs.existsSync(imagePath)).toBe(true);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
 
     "esModuleInterop": true
   },
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "build", "tests", "uploads"]
 }


### PR DESCRIPTION
# Pull Request: Cambio de imagen en base64 a URL publica
## Descripción
Se ha cambiado la forma de gestionar las imagenes en nuestra API, ahora se pasa de guardar en base de datos el contenido de la imagen en base64 a convertir el base64 a un archivo .png y guardar en base de datos la url publica de dicha imagen. Haciendo que sea menos pesado el procesamiento.

## Cambios Realizados
- Modificacion de la clase helper encargada de la gestion de imagenes
- Modificacion de los endpoints para el uso de la nueva gestion
- Creación de nuevos parametros en el archivo .env

## Issues Relacionados

## Comprobación de Código
- [x] El código sigue los estándares de estilo y convenciones de la API.
- [ ] Se han agregado pruebas unitarias para las nuevas funcionalidades o se han actualizado las existentes.
- [ ] La documentación se ha actualizado/refinado para reflejar los cambios realizados.
- [x] No hay errores o advertencias en la consola.
 
## Comentarios Adicionales (si aplica)
